### PR TITLE
Update log schematic tables

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1052,16 +1052,17 @@ mts_save("acacia_bush", {
 -- Apple tree log
 
 mts_save("apple_log", {
-	size = {x = 3, y = 3, z = 1},
+	size = {x = 5, y = 2, z = 1},
 	data = {
-		{name = "air", prob = 0},
-		{name = "air", prob = 0},
-		{name = "air", prob = 0},
-		{name = "default:tree", param2 = 12, prob = 191},
+		{name = "default:tree", param2 = 12, prob = 127},
+		{name = "default:tree", param2 = 12},
+		{name = "default:tree", param2 = 12},
 		{name = "default:tree", param2 = 12},
 		{name = "default:tree", param2 = 12, prob = 127},
 		{name = "air", prob = 0},
+		{name = "air", prob = 0},
 		{name = "flowers:mushroom_brown", prob = 63},
+		{name = "air", prob = 0},
 		{name = "air", prob = 0},
 	},
 })
@@ -1069,16 +1070,17 @@ mts_save("apple_log", {
 -- Jungletree log
 
 mts_save("jungle_log", {
-	size = {x = 3, y = 3, z = 1},
+	size = {x = 5, y = 2, z = 1},
 	data = {
-		{name = "air", prob = 0},
-		{name = "air", prob = 0},
-		{name = "air", prob = 0},
-		{name = "default:jungletree", param2 = 12, prob = 191},
+		{name = "default:jungletree", param2 = 12, prob = 127},
+		{name = "default:jungletree", param2 = 12},
+		{name = "default:jungletree", param2 = 12},
 		{name = "default:jungletree", param2 = 12},
 		{name = "default:jungletree", param2 = 12, prob = 127},
 		{name = "air", prob = 0},
+		{name = "air", prob = 0},
 		{name = "flowers:mushroom_brown", prob = 127},
+		{name = "air", prob = 0},
 		{name = "air", prob = 0},
 	},
 })
@@ -1086,16 +1088,17 @@ mts_save("jungle_log", {
 -- Pine tree log
 
 mts_save("pine_log", {
-	size = {x = 3, y = 3, z = 1},
+	size = {x = 5, y = 2, z = 1},
 	data = {
-		{name = "air", prob = 0},
-		{name = "air", prob = 0},
-		{name = "air", prob = 0},
-		{name = "default:pine_tree", param2 = 12, prob = 191},
+		{name = "default:pine_tree", param2 = 12, prob = 127},
+		{name = "default:pine_tree", param2 = 12},
+		{name = "default:pine_tree", param2 = 12},
 		{name = "default:pine_tree", param2 = 12},
 		{name = "default:pine_tree", param2 = 12, prob = 127},
 		{name = "air", prob = 0},
+		{name = "air", prob = 0},
 		{name = "flowers:mushroom_red", prob = 63},
+		{name = "air", prob = 0},
 		{name = "air", prob = 0},
 	},
 })
@@ -1103,12 +1106,11 @@ mts_save("pine_log", {
 -- Acacia tree log
 
 mts_save("acacia_log", {
-	size = {x = 3, y = 2, z = 1},
+	size = {x = 5, y = 1, z = 1},
 	data = {
-		{name = "air", prob = 0},
-		{name = "air", prob = 0},
-		{name = "air", prob = 0},
-		{name = "default:acacia_tree", param2 = 12, prob = 191},
+		{name = "default:acacia_tree", param2 = 12, prob = 127},
+		{name = "default:acacia_tree", param2 = 12},
+		{name = "default:acacia_tree", param2 = 12},
 		{name = "default:acacia_tree", param2 = 12},
 		{name = "default:acacia_tree", param2 = 12, prob = 127},
 	},
@@ -1117,16 +1119,17 @@ mts_save("acacia_log", {
 -- Aspen tree log
 
 mts_save("aspen_log", {
-	size = {x = 3, y = 3, z = 1},
+	size = {x = 5, y = 2, z = 1},
 	data = {
-		{name = "air", prob = 0},
-		{name = "air", prob = 0},
-		{name = "air", prob = 0},
+		{name = "default:aspen_tree", param2 = 12, prob = 127},
+		{name = "default:aspen_tree", param2 = 12},
 		{name = "default:aspen_tree", param2 = 12},
 		{name = "default:aspen_tree", param2 = 12},
 		{name = "default:aspen_tree", param2 = 12, prob = 127},
+		{name = "air", prob = 0},
 		{name = "flowers:mushroom_red", prob = 63},
 		{name = "flowers:mushroom_brown", prob = 63},
+		{name = "air", prob = 0},
 		{name = "air", prob = 0},
 	},
 })


### PR DESCRIPTION
@paramat Updates for log schematics as per current MTG PR to improve logs. 

Please note that saveschems does these a bit differently than I do, so these are not actually the tables I used, but (so long as I am understanding the format correctly) they will be the exact equivalents. 